### PR TITLE
Fix for bug 002 to match component_id schema in bugzilla 5.2

### DIFF
--- a/Extension.pm
+++ b/Extension.pm
@@ -43,7 +43,7 @@ sub db_schema_abstract_schema {
                 }
             },
             component_id => {
-                TYPE    => 'INT2',
+                TYPE    => 'INT3',
                 NOTNULL => 0,
                 REFERENCES => {
                     TABLE  => 'components',


### PR DESCRIPTION
At some point (unsure of the version), the component_id schema was changed from INT2 to INT3.  Making this fix allows the extension to be installed with bugzilla 5.2 and work properly.